### PR TITLE
Added a Margin to the Bottom

### DIFF
--- a/template.html
+++ b/template.html
@@ -17,6 +17,11 @@
   width: 320px;
   height: 115px;
 }
+
+.container{
+    margin-bottom: 2em;
+}
+
 </style>
 
 <body>


### PR DESCRIPTION
The current page doesn't have a margin on the bottom, so the last row of graphs comes in to contact with the window.

![](http://i.imgur.com/6L87HPK.png)

I've added a small margin (`2em`) to the bottom of `.container` to prevent that from happening.

![](http://i.imgur.com/FginwWm.png)

&mdash; @citruspi
