### PR TITLE
Linked Graphs to the Source

### DIFF
--- a/template.html
+++ b/template.html
@@ -54,7 +54,7 @@
   </div></div>
   <div class="row">
     <div class="col-md-4">
-      <a target="_blank" href="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_out;begin=-${span}">
+      <a target="_blank" href="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_in;begin=-${span}">
         <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_in;begin=-${span}">
       </a>
     </div>

--- a/template.html
+++ b/template.html
@@ -54,13 +54,19 @@
   </div></div>
   <div class="row">
     <div class="col-md-4">
-      <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_in;begin=-${span}">
+      <a target="_blank" href="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_out;begin=-${span}">
+        <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_in;begin=-${span}">
+      </a>
     </div>
     <div class="col-md-4">
-      <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_out;begin=-${span}">
+      <a target="_blank" href="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_out;begin=-${span}">
+        <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=gauge;type_instance=${params['consumer']}_out;begin=-${span}">
+      </a>
     </div>
     <div class="col-md-4">
-      <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=queue_length;type_instance=${params['consumer']}_backlog;begin=-${span}">
+      <a target="_blank" href="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=queue_length;type_instance=${params['consumer']}_backlog;begin=-${span}">
+        <img class="graph center-block" src="https://admin.fedoraproject.org/collectd/bin/graph.cgi?hostname=${params['host']};plugin=${params['plugin']};plugin_instance=${params['instance']};type=queue_length;type_instance=${params['consumer']}_backlog;begin=-${span}">
+      </a>
     </div>
   </div>
   % endfor


### PR DESCRIPTION
While it makes sense that clicking on the headings (e.g. `datanommer`, `gateway`, `relay`, etc.) brings that section into focus, when I click on an image, it's primarily because I want to see it better.

Adding a lightbox might be a prettier solution, but I figured wrapping graphs in a link to the image source is simple and works well enough.

&mdash; @citruspi
